### PR TITLE
Add tenant context propagation via AsyncLocalStorage

### DIFF
--- a/tenancy-service/src/context/tenant-context.ts
+++ b/tenancy-service/src/context/tenant-context.ts
@@ -1,0 +1,56 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { Request, Response, NextFunction } from "express";
+import { verify } from "jsonwebtoken";
+
+interface TenantContext {
+  tenantId: string;
+  tenantName: string;
+  plan: "starter" | "professional" | "enterprise";
+  features: string[];
+}
+
+const tenantStorage = new AsyncLocalStorage<TenantContext>();
+
+export function getTenantContext(): TenantContext | undefined {
+  return tenantStorage.getStore();
+}
+
+export function requireTenantContext(): TenantContext {
+  const ctx = tenantStorage.getStore();
+  if (\!ctx) {
+    throw new Error("Tenant context not available. Ensure tenantMiddleware is applied.");
+  }
+  return ctx;
+}
+
+export function tenantMiddleware(jwtSecret: string) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const authHeader = req.headers.authorization;
+    if (\!authHeader?.startsWith("Bearer ")) {
+      return next(new Error("Missing or invalid authorization header"));
+    }
+
+    const token = authHeader.slice(7);
+
+    try {
+      const decoded = verify(token, jwtSecret) as {
+        tenant_id: string;
+        tenant_name: string;
+        plan: string;
+        features: string[];
+      };
+
+      const context: TenantContext = {
+        tenantId: decoded.tenant_id,
+        tenantName: decoded.tenant_name,
+        plan: decoded.plan as TenantContext["plan"],
+        features: decoded.features ?? [],
+      };
+
+      tenantStorage.run(context, () => next());
+    } catch (err) {
+      next(new Error("Invalid or expired tenant token"));
+    }
+  };
+}
+


### PR DESCRIPTION
## Summary
- Implements tenant context extraction from JWT tokens
- Propagates tenant_id through request lifecycle using Node.js AsyncLocalStorage
- Provides `getTenantContext()` and `requireTenantContext()` helpers for downstream services
- Middleware validates Bearer tokens and establishes tenant scope

## Context
This unblocks the cloud migration epic (#1) and resolves the cross-team dependency (#8). The API gateway and device-service teams can now consume tenant context without direct coupling to the auth layer.

## Test Plan
- [ ] Unit test: middleware extracts tenant from valid JWT
- [ ] Unit test: middleware rejects missing/invalid tokens
- [ ] Integration test: tenant context available in downstream handlers
- [ ] Integration test: AsyncLocalStorage correctly scopes across async boundaries

Part of #1, unblocks #8